### PR TITLE
Added Package Name and Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "ToolJet",
+  "version": "1.17.3",
   "engines": {
     "node": "14.17.3",
     "npm": "7.20.0"


### PR DESCRIPTION
For Me the npm was not installing the package and it's reason was that this package is not have `name` and `version` key specified.
don't know why it happened but most of my project don't need that data